### PR TITLE
Fix GDI+ exception when exporting as jpg

### DIFF
--- a/src/xps2img/Xps2Image.cs
+++ b/src/xps2img/Xps2Image.cs
@@ -161,13 +161,11 @@ namespace xps2img
             var bitmapEncoder = CreateEncoder(parameters.ImageType, parameters.ImageOptions);
             var bitmapSource = GetPageBitmap(_xpsDocumentPaginator, docPageNumber, parameters);
 
-            using (var stream = new MemoryStream())
-            {
-                bitmapEncoder.Frames.Add(BitmapFrame.Create(bitmapSource));
-                bitmapEncoder.Save(stream);
+            var stream = new MemoryStream();
+            bitmapEncoder.Frames.Add(BitmapFrame.Create(bitmapSource));
+            bitmapEncoder.Save(stream);
 
-                return new Bitmap(stream);
-            }
+            return new Bitmap(stream);
         }
 
         private RenderTargetBitmap GetPageBitmap(DocumentPaginator documentPaginator, int pageNumber, Parameters parameters)


### PR DESCRIPTION
See this answer by Jon Skeet which details the behaviour of Bitmap and why this causes an exception: http://stackoverflow.com/a/336396/184746
